### PR TITLE
Avoid rendering docs on PRs

### DIFF
--- a/.github/workflows/render-documentation.yml
+++ b/.github/workflows/render-documentation.yml
@@ -26,3 +26,4 @@ jobs:
       source-path: './src'
       target-path: './docs/api.md'
       fail-on-warnings: true
+      commit: ${{ github.event_name != 'pull_request' }} # Only commit changes if not a PR


### PR DESCRIPTION
This PR avoids committing the rendered documentation from PRs. The documentation is still validated however.